### PR TITLE
Add offset option to search after 3th keystroke

### DIFF
--- a/wp-content/themes/access/src/js/modules/office-map.js
+++ b/wp-content/themes/access/src/js/modules/office-map.js
@@ -57,7 +57,8 @@ class OfficeMap {
     });
 
     /** @private {google.maps.places.SearchBox} Search box controller. */
-    this._searchBox = new google.maps.places.SearchBox(this._searchEl);
+    this._searchBox = new google.maps.places
+        .SearchBox(this._searchEl, {offset: 3});
 
     /** @private {OfficeFilter} Program filter controller. */
     this._filter = new OfficeFilter(this._filterEl);


### PR DESCRIPTION
From the docs of the places autocomplete: 

> offset — The position, in the input term, of the last character that the service uses to match predictions. For example, if the input is 'Google' and the offset is 3, the service will match on 'Goo'. The string determined by the offset is matched against the first word in the input term only. For example, if the input term is 'Google abc' and the offset is 3, the service will attempt to match against 'Goo abc'. If no offset is supplied, the service will use the whole term. The offset should generally be set to the position of the text caret.

https://developers.google.com/places/web-service/autocomplete