### PR TITLE
Decode URL to make unicode characters valid UTF-8

### DIFF
--- a/wp-content/db.php
+++ b/wp-content/db.php
@@ -1,0 +1,1 @@
+/var/www/html/wp-content/plugins/query-monitor/wp-content/db.php

--- a/wp-content/themes/access/functions.php
+++ b/wp-content/themes/access/functions.php
@@ -23,3 +23,10 @@ Path\require_blocks();
 require_once Path\controller('site');
 
 new Controller\Site();
+
+/**
+ * Add filter to Twig
+ */
+
+add_filter('timber/twig', 'add_to_twig');
+

--- a/wp-content/themes/access/lib/functions.php
+++ b/wp-content/themes/access/lib/functions.php
@@ -102,6 +102,23 @@ function validate_params($namespace, $subject) {
 }
 
 /**
+ * Adds functionality to Twig.
+ *
+ * @param \Twig\Environment $twig The Twig environment.
+ * @return \Twig\Environment
+ */
+function add_to_twig( $twig ) {
+    // Adding functions as filters.
+    $twig->addFilter( new Timber\Twig_Filter( 'url_decode', 'url_decode' ) );
+
+    return $twig;
+}
+
+function url_decode( $text ) {
+    return  urldecode($text);
+}
+
+/**
  * Creates a shareable url along with valid hash
  * @param  array $params Requires programs, categories, date, guid, share_link
  * @return array         0; the url 1; the hash

--- a/wp-content/themes/access/views/locations/single-location.twig
+++ b/wp-content/themes/access/views/locations/single-location.twig
@@ -125,7 +125,7 @@
 
             {% include 'components/accordion.twig' with {
               this: {
-                id: program.slug,
+                id: function('url_decode', program.slug),
                 active: (loop.index == 1) ? true : false,
                 header: header,
                 body: body,

--- a/wp-content/themes/access/views/partials/html-header.twig
+++ b/wp-content/themes/access/views/partials/html-header.twig
@@ -1,4 +1,4 @@
-<meta charset="utf-8">
+<meta charset="UTF-8">
 <meta name="viewport" content="width=device-width, initial-scale=1.0"/>
 <meta http-equiv="X-UA-Compatible" content="IE=edge,chrome=1">
 


### PR DESCRIPTION
It seems somewhere along the line the slug use in the id for the toggle
component got encoded. The urlencoded %e2%80%8b string represents
U+E2808B which is a zero-width-space. This is the reason why the toggle
function wouldn't work in the locations page.

The solution is to use PHP method urldecode to decode the slug. Thus,
converting the unicode into valid UTF-8. This was a sneaky bug.

** related
https://stackoverflow.com/questions/60157884/twig-how-to-interpolate-within-json?noredirect=1#comment106402222_60157884

https://www.php.net/manual/en/function.urldecode.php