### PR TITLE
Create base and organize other schemas

### DIFF
--- a/wp-content/themes/access/controllers/homepage-tout.php
+++ b/wp-content/themes/access/controllers/homepage-tout.php
@@ -32,8 +32,6 @@ class HomepageTout extends Timber\Post {
      * Structured Data
      */
 
-    $this->item_scope = $this->getItemScope();
-
     // Use the post permalink for the url if post relationship is present
     $this->link_url = ($this->link_to_content) ? get_permalink($this->link_to_content[0]) : $this->link_url;
 
@@ -80,18 +78,25 @@ class HomepageTout extends Timber\Post {
   }
 
   /**
-   * Get the itemtype for structure data
+   * Get the special announcement schema if the tout
    *
-   * @return  String  The itemtype
+   * @return  Array/Boolean  Returns the schema object if covid-response else false
    */
-
-  public function getItemScope() {
-    $item_scope = false;
-
-    if ($this->custom['tout_status_type'] == 'covid-response') {
-      $item_scope = 'SpecialAnnouncement';
-    }
-
-    return $item_scope;
+  public function getSchema() {
+    return ($this->status_type === 'covid-response') ?
+      array(
+        '@context' => 'https://schema.org',
+        '@type' => 'SpecialAnnouncement',
+        'name' => $this->tout_title,
+        'newsUpdatesAndGuidelines' => $this->link_url,
+        'datePosted' => $this->post_modified,
+        'expires' => $this->custom['tout_status_clear_date'],
+        'text' => $this->link_text,
+        'category' => 'https://www.wikidata.org/wiki/Q81068910',
+        'spatialCoverage' => [
+          'type' => 'City',
+          'name' => 'New York'
+        ]
+      ) : false;
   }
 }

--- a/wp-content/themes/access/controllers/location.php
+++ b/wp-content/themes/access/controllers/location.php
@@ -43,6 +43,7 @@ class Location extends Timber\Post {
 
   /**
    * Returns the phone number for the location shown.
+   *
    * @return  Array  Phone number and extension.
    */
   public function getPhone() {
@@ -52,6 +53,7 @@ class Location extends Timber\Post {
 
   /**
    * Returns the URL to a map of the location.
+   *
    * @return  String  URL of the map location.
    */
   public function locationMapURL() {
@@ -62,6 +64,7 @@ class Location extends Timber\Post {
 
   /**
    * Returns the type of the location.
+   *
    * @return  String  type of location.
    */
   public function locationType() {
@@ -95,7 +98,8 @@ class Location extends Timber\Post {
   /**
    * Fetches nearby stops using transient stops storied in the database
    * via the NYCO transients plugin.
-   * @return [array] Collection of nearby stops.
+   *
+   * @return  Array  Collection of nearby stops.
    */
   public function nearbyStops() {
     if (!class_exists('NYCO\Transients')) {
@@ -120,9 +124,11 @@ class Location extends Timber\Post {
    * This compares the latitude and longitude with the Subway Stops data, sorts
    * the data by distance from closest to farthest, and returns the stop and
    * distances of the stations.
-   * @param  {object} el    The DOM Component with the data attr options
-   * @param  {object} stops All of the stops data to compare to
-   * @return {object}       A collection of the closest stops with distances
+   *
+   * @param   Number  $lat  Latitude of location
+   * @param   Number  $lon  Longitude of location
+   *
+   * @return  Array         A collection of the closest stops with distances
    */
   private function nearbyStopsLocate($lat, $lon) {
     $geo = [];
@@ -164,11 +170,13 @@ class Location extends Timber\Post {
   /**
    * Returns distance in miles comparing the latitude and longitude of two
    * points using decimal degrees.
-   * @param  {float} lat1 Latitude of point 1 (in decimal degrees)
-   * @param  {float} lon1 Longitude of point 1 (in decimal degrees)
-   * @param  {float} lat2 Latitude of point 2 (in decimal degrees)
-   * @param  {float} lon2 Longitude of point 2 (in decimal degrees)
-   * @return {float}      The distance in miles between each coordinate.
+   *
+   * @param   Float  lat1  Latitude of point 1 (in decimal degrees)
+   * @param   Float  lon1  Longitude of point 1 (in decimal degrees)
+   * @param   Float  lat2  Latitude of point 2 (in decimal degrees)
+   * @param   Float  lon2  Longitude of point 2 (in decimal degrees)
+   *
+   * @return  Float        The distance in miles between each coordinate.
    */
   private function equirectangular($lat1, $lon1, $lat2, $lon2) {
     $alpha = abs($lon2) - abs($lon1);
@@ -182,8 +190,10 @@ class Location extends Timber\Post {
 
   /**
    * Assigns trunk slugs to the data using the TRUNKS dictionary.
-   * @param  {object} locations Object of closest locations
-   * @return {object}           Same object with colors assigned to each loc
+   *
+   * @param   Array  locations  Object of closest locations
+   *
+   * @return  Array             Same object with colors assigned to each loc
    */
   private function nearbyStopsColors($locations) {
     $trunk = 'shuttles';
@@ -210,6 +220,33 @@ class Location extends Timber\Post {
     }
 
     return $locations;
+  }
+
+  /**
+   * Get structured data for this location
+   *
+   * @return  Array  Structured data object
+   */
+  public function getSchema() {
+    return array(
+      '@context' => 'https://schema.org',
+      '@type' => $this->locationType(),
+      'name' => $this->title,
+      'hasMap' => $this->locationMapURL(),
+      'description' => $this->getHelp(),
+      'address' => array(
+        '@type' => 'PostalAddress',
+        'streetAddress' => $this->address_street,
+        'addressLocality' => $this->city,
+        'postalCode' => $this->zip
+      ),
+      'telephone' => $this->getPhone(),
+      'sameAs' => $this->website,
+      'spatialCoverage' => array(
+        'type' => 'City',
+        'name' => 'New York'
+      )
+    );
   }
 
   /**

--- a/wp-content/themes/access/controllers/site.php
+++ b/wp-content/themes/access/controllers/site.php
@@ -26,22 +26,17 @@ class Site extends TimberSite {
 
   /**
    * Make variables available globally to twig templates
-   * @param   object  $context  The timber site context variable
-   * @return  object            The modified timber site context variable
+   *
+   * @param   Object  $context  The timber site context variable
+   *
+   * @return  Object            The modified timber site context variable
    */
   public function addToContext($context) {
-    include_once ABSPATH . 'wp-admin/includes/plugin.php';
+    $lang = $this->getLanguageCode();
 
-    /**
-     * The current language code using the WPML constant.
-     * This will only change if WPML is activated.
-     */
-
-    $wpml = 'sitepress-multilingual-cms/sitepress.php';
-    $lang = is_plugin_active($wpml) ? ICL_LANGUAGE_CODE : 'en';
     $direction = ($lang === 'ar' || $lang === 'ur') ? 'rtl' : 'ltr';
 
-    $context['language_code'] = is_plugin_active($wpml) ? ICL_LANGUAGE_CODE : 'en';
+    $context['language_code'] = $lang;
 
     $context['direction'] = $direction;
 
@@ -97,17 +92,6 @@ class Site extends TimberSite {
     /** Implement schema for sitewide alert */
     $alert_sitewide = $context['alert_sitewide'];
 
-    if ($alert_sitewide->item_scope === 'SpecialAnnouncement') {
-      $context['alert_sitewide_schema'] = array(
-        '@context' => 'https://schema.org',
-        '@type' => 'SpecialAnnouncement',
-        'name' => $alert_sitewide->post_title,
-        'datePosted' => $alert_sitewide->post_modified,
-        'text' => $alert_sitewide->alert_content,
-        'category' => 'https://www.wikidata.org/wiki/Q81068910'
-      );
-    }
-
     /** Determine if page is in print view */
     $context['is_print'] = isset($_GET['print']) ? $_GET['print'] : false;
 
@@ -117,7 +101,28 @@ class Site extends TimberSite {
     /** Create nonce for allowed resources */
     $context['csp_script_nonce'] = (defined('CSP_SCRIPT_NONCE')) ? CSP_SCRIPT_NONCE : false;
 
+    /** Set Schema Base */
+    $context['schema'] = array_filter(array(
+      $this->getOrganizationSchema(),
+      $this->getWebsiteSchema(),
+      $this->getAlertSchema($alert_sitewide)
+    ));
+
     return $context;
+  }
+
+  /**
+   * The current language code using the WPML constant. This will only change
+   * if WPML is activated.
+   *
+   * @return  String  The current language code
+   */
+  public function getLanguageCode() {
+    include_once ABSPATH . 'wp-admin/includes/plugin.php';
+
+    $wpml = 'sitepress-multilingual-cms/sitepress.php';
+
+    return is_plugin_active($wpml) ? ICL_LANGUAGE_CODE : 'en';
   }
 
   /**
@@ -165,8 +170,8 @@ class Site extends TimberSite {
 
   /**
    * Get the default meta of the page if it exists.
-
-   * @return  string         The view description
+   *
+   * @return  String  The view description
    */
   public function getPageMetaDescription() {
     /**
@@ -196,5 +201,85 @@ class Site extends TimberSite {
     }
 
     return '';
+  }
+
+  /**
+   * Get the organization schema
+   *
+   * @return  Array  Schema object
+   */
+  public function getOrganizationSchema() {
+    return array(
+      '@context' => 'https://schema.org',
+      '@type' => 'Organization',
+      '@id' => get_site_url() . '/#organization',
+      'name' => get_bloginfo('title'),
+      'url' => get_site_url(),
+      'logo' => array(
+        '@type' => 'ImageObject',
+        '@id' => get_site_url() . '/#logo',
+        'url' => get_stylesheet_directory_uri() . '/assets/img/apple-icon-precomposed.png',
+        'width' => 192,
+        'height' => 192,
+        'caption' => get_bloginfo('title')
+      ),
+    );
+  }
+
+  /**
+   * Get the Website Schema
+   *
+   * @return  Array  Schema object
+   */
+  public function getWebsiteSchema() {
+    return array(
+      '@context' => 'https://schema.org',
+      '@type' => 'WebSite',
+      '@id' => get_site_url() . '/#website',
+      'url' => get_site_url(),
+      'name' => get_bloginfo('title'),
+      'description' => get_bloginfo('description'),
+      'publisher' => array(
+        '@id' => get_site_url() . '/#organization'
+      ),
+      'potentialAction' => [
+        array(
+          '@type' => 'FindAction',
+          'target' => get_site_url() . '/eligibility'
+        ),
+        array(
+          '@type' => 'FindAction',
+          'target' => get_site_url() . '/programs'
+        ),
+        array(
+          '@type' => 'FindAction',
+          'target' => get_site_url() . '/locations'
+        ),
+        array(
+          '@type' => 'SearchAction',
+          'target' => get_site_url() . '/?s={search_term_string}',
+          'query-input' => 'required name=search_term_string'
+        )
+      ],
+      'inLanguage' => $this->getLanguageCode()
+    );
+  }
+
+  /**
+   * Get the sitewide alert schema
+   *
+   * @param   Object         $alert  The alert object
+   *
+   * @return  Array/Boolean          If the alert is a special announcement
+   */
+  public function getAlertSchema($alert) {
+    return ($alert->item_scope === 'SpecialAnnouncement') ? array(
+      '@context' => 'https://schema.org',
+      '@type' => 'SpecialAnnouncement',
+      'name' => $alert->post_title,
+      'datePosted' => $alert->post_modified,
+      'text' => $alert->alert_content,
+      'category' => 'https://www.wikidata.org/wiki/Q81068910'
+    ) : false;
   }
 }

--- a/wp-content/themes/access/single-location.php
+++ b/wp-content/themes/access/single-location.php
@@ -2,7 +2,6 @@
 
 /**
  * Location Detail Page
- *
  * @author Blue State Digital
  */
 
@@ -11,6 +10,7 @@ require_once ACCESS\controller('alert');
 
 /**
  * Enqueue
+ * @author NYC Opportunity
  */
 
 // Main
@@ -38,35 +38,11 @@ $context = Timber::get_context();
 $context['post'] = $location;
 
 /**
- * Setup schema for Single Location
+ * Add to Schema
+ * @author NYC Opportunity
  */
 
-$context['schema'] = [
-  array(
-    '@context' => 'https://schema.org',
-    '@type' => $location->locationType(),
-    'name' => $location->title,
-    'hasMap' => $location->locationMapURL(),
-    'description' => $location->getHelp(),
-    'address' => [
-      '@type' => 'PostalAddress',
-      'streetAddress' => $location->address_street,
-      'addressLocality' => $location->city,
-      'postalCode' => $location->zip
-    ],
-    'telephone' => $location->getPhone(),
-    'sameAs' => $location->website,
-    'spatialCoverage' => [
-      'type' => 'City',
-      'name' => 'New York'
-    ]
-  )
-];
-
-if ($context['alert_sitewide_schema']) {
-  array_push($context['schema'], $context['alert_sitewide_schema']);
-}
-
+$context['schema'][] = $location->getSchema();
 $context['schema'] = json_encode($context['schema']);
 
 /**
@@ -75,9 +51,9 @@ $context['schema'] = json_encode($context['schema']);
 
 $context['page_meta_description'] = $location->getPageMetaDescription();
 
-
 /**
  * Alerts
+ * @author NYC Opportunity
  */
 
 if (get_field('alert')) {

--- a/wp-content/themes/access/single-page-legacy.php
+++ b/wp-content/themes/access/single-page-legacy.php
@@ -2,7 +2,6 @@
 
 /**
  * Template name: Legacy Page
- *
  * @author NYC Opportunity
  */
 
@@ -11,6 +10,7 @@ require_once ACCESS\controller('page');
 
 /**
  * Enqueue
+ * @author NYC Opportunity
  */
 
 // Main
@@ -42,6 +42,7 @@ $context['post'] = $page;
 
 /**
  * Set Alerts
+ * @author NYC Opportunity
  */
 
 if (get_field('alert')) {
@@ -64,16 +65,17 @@ $context['alerts'] = array_map(function($post) {
 
 /**
  * Show Google Translate
+ * @author NYC Opportunity
  */
 
 $context['google_translate_element'] = true;
 
 /**
- * Set up schema
+ * Add to Schema
+ * @author NYC Opportunity
  */
 
 $context['schema'][] = $page->getSchema();
-$context['schema'][] = $context['alert_sitewide_schema'];
 $context['schema'] = json_encode(array_filter($context['schema']));
 
 /**

--- a/wp-content/themes/access/single-programs.php
+++ b/wp-content/themes/access/single-programs.php
@@ -11,6 +11,7 @@ require_once ACCESS\controller('alert');
 
 /**
  * Enqueue
+ * @author NYC Opportunity
  */
 
 // Main
@@ -35,7 +36,10 @@ $program = new Controller\Programs();
 
 $context = Timber::get_context();
 
-// Gets the url parameter on the page for navigating each section.
+/**
+ * Gets the url parameter on the page for navigating each section
+ * @author Blue State Digital
+ */
 if (isset($_GET['step'])) {
   $context['step'] = urlencode(
     validate_params('step', urldecode(htmlspecialchars($_GET['step'])))
@@ -47,23 +51,13 @@ if (isset($_GET['step'])) {
 $context['post'] = $program;
 
 /**
- * Schema
+ * Add to schema
+ * @author NYC Opportunity
  */
-$context['schema'] = $program->getSchema();
 
-if ($program->getItemScope() === 'SpecialAnnouncement') {
-  $special_announcement = $program->getSpecialAnnouncementSchema();
-  array_push($context['schema'], $special_announcement);
-}
-
-if ($program->getFaqSchema()) {
-  $faq = $program->getFaqSchema();
-  array_push($context['schema'], $faq);
-}
-
-if ($context['alert_sitewide_schema']) {
-  array_push($context['schema'], $context['alert_sitewide_schema']);
-}
+$context['schema'][] = $program->getSchema();
+$context['schema'][] = $program->getSpecialAnnouncementSchema();
+$context['schema'][] = $program->getFaqSchema();
 
 $context['schema'] = mb_convert_encoding($context['schema'], 'UTF-8', 'auto');
 $context['schema'] = json_encode($context['schema']);

--- a/wp-content/themes/access/singular.php
+++ b/wp-content/themes/access/singular.php
@@ -73,7 +73,6 @@ $context['google_translate_element'] = true;
  */
 
 $context['schema'][] = $page->getSchema();
-$context['schema'][] = $context['alert_sitewide_schema'];
 $context['schema'] = json_encode(array_filter($context['schema']));
 
 /**

--- a/wp-content/themes/access/views/programs/determine-your-eligibility.twig
+++ b/wp-content/themes/access/views/programs/determine-your-eligibility.twig
@@ -4,8 +4,8 @@
   </header>
 
   {% if post.plain_language_eligibility | length %}
-    <div itemprop="audience" itemtype="http://schema.org/Audience" itemscope>
-      <div itemprop="name" class="o-content mb-4">
+    <div>
+      <div class="o-content mb-4">
         {{ post.get_field('field_58912c1a8a82d')|add_anyc_checklist|add_anyc_table_numeric }} {# plain_language_eligibility #}
       </div>
     </div>


### PR DESCRIPTION
Create base schema in site controller that includes:

- Organization with logo
- Website with potential actions
- Sitewide Alert (if special announcement)

Move schemas from view template controllers into post controllers.

Simplify adding to schemas.