### PR TITLE
Reduce latency to requests by using DNS prefetch

### DIFF
--- a/wp-content/mu-plugins/wp-headers.php
+++ b/wp-content/mu-plugins/wp-headers.php
@@ -12,6 +12,13 @@ add_action('wp_headers', function() {
     return;
   }
 
+  // X-DNS-Prefetch-Control - Proactively perform domain name resolution on both
+  // links that the user may choose to follow as well as URLs for items
+  // eferenced by the document
+  if (defined('WP_HEADERS_DNS_PREFETCH_CONTROL') && WP_HEADERS_DNS_PREFETCH_CONTROL) {
+    header('X-DNS-Prefetch-Control: ' . WP_HEADERS_DNS_PREFETCH_CONTROL);
+  }
+
   // X-Frame-Options: SAMEORIGIN - Prevent web pages from being loaded inside iFrame
   if (defined('WP_HEADERS_SAMEORIGIN') && WP_HEADERS_SAMEORIGIN) {
     header('X-Frame-Options: SAMEORIGIN');

--- a/wp-content/themes/access/archive-location.php
+++ b/wp-content/themes/access/archive-location.php
@@ -35,20 +35,32 @@ enqueue_script('main');
 enqueue_script('archive-location');
 
 /**
- * Manually prefetch asset DNS
+ * Manual DNS prefetch and preconnect headers
+ *
  * @author NYC Opportunity
  */
 
-add_action('wp_head', function(){
-  echo '<meta http-equiv="x-dns-prefetch-control" content="on">
-  <link rel="preconnect" href="https://maps.googleapis.com" crossorigin>
-  <link rel="dns-prefetch" href="https://maps.googleapis.com" >
-  <link rel="preconnect" href="https://maps.gstatic.com" crossorigin>
-  <link rel="dns-prefetch" href="https://maps.gstatic.com" >
-  <link rel="preconnect" href="https://fonts.gstatic.com/" crossorigin>
-  <link rel="dns-prefetch" href="https://fonts.gstatic.com" >';
-}, 0);
+add_filter('wp_resource_hints', function($urls, $relation_type) {
+  switch ($relation_type) {
+    // case 'preconnect':
+    //   // Add preconnect most critical assets here?
+    //   break;
 
+    case 'dns-prefetch':
+      $urls = array_merge($urls, [
+        'https://s.webtrends.com',
+        'https://www.google-analytics.com',
+        'https://cdnjs.cloudflare.com',
+        'https://fonts.googleapis.com',
+        'https://maps.gstatic.com',
+        'https://maps.googleapis.com'
+      ]);
+
+      break;
+  }
+
+  return $urls;
+}, 10, 2);
 
 /**
  * Context

--- a/wp-content/themes/access/archive-location.php
+++ b/wp-content/themes/access/archive-location.php
@@ -42,9 +42,14 @@ enqueue_script('archive-location');
 
 add_filter('wp_resource_hints', function($urls, $relation_type) {
   switch ($relation_type) {
-    // case 'preconnect':
-    //   // Add preconnect most critical assets here?
-    //   break;
+    case 'preconnect':
+      $urls = array_merge($urls, [
+        'https://cdnjs.cloudflare.com',
+        'https://maps.gstatic.com',
+        'https://maps.googleapis.com'
+      ]);
+
+      break;
 
     case 'dns-prefetch':
       $urls = array_merge($urls, [

--- a/wp-content/themes/access/archive-location.php
+++ b/wp-content/themes/access/archive-location.php
@@ -35,6 +35,22 @@ enqueue_script('main');
 enqueue_script('archive-location');
 
 /**
+ * Manually prefetch asset DNS
+ * @author NYC Opportunity
+ */
+
+add_action('wp_head', function(){
+  echo '<meta http-equiv="x-dns-prefetch-control" content="on">
+  <link rel="preconnect" href="https://maps.googleapis.com" crossorigin>
+  <link rel="dns-prefetch" href="https://maps.googleapis.com" >
+  <link rel="preconnect" href="https://maps.gstatic.com" crossorigin>
+  <link rel="dns-prefetch" href="https://maps.gstatic.com" >
+  <link rel="preconnect" href="https://fonts.gstatic.com/" crossorigin>
+  <link rel="dns-prefetch" href="https://fonts.gstatic.com" >';
+}, 0);
+
+
+/**
  * Context
  */
 

--- a/wp-content/themes/access/archive-location.php
+++ b/wp-content/themes/access/archive-location.php
@@ -35,7 +35,11 @@ enqueue_script('main');
 enqueue_script('archive-location');
 
 /**
- * Manual DNS prefetch and preconnect headers
+ * Manual DNS prefetch and preconnect headers that are not added through
+ * enqueueing functions above. DNS prefetch is added automatically. Preconnect
+ * headers always need to be added manually.
+ *
+ * @link https://developer.mozilla.org/en-US/docs/Web/Performance/dns-prefetch
  *
  * @author NYC Opportunity
  */
@@ -44,21 +48,21 @@ add_filter('wp_resource_hints', function($urls, $relation_type) {
   switch ($relation_type) {
     case 'preconnect':
       $urls = array_merge($urls, [
-        'https://cdnjs.cloudflare.com',
-        'https://maps.gstatic.com',
-        'https://maps.googleapis.com'
+        '//cdnjs.cloudflare.com',
+        '//maps.gstatic.com',
+        '//maps.googleapis.com'
       ]);
 
       break;
 
     case 'dns-prefetch':
       $urls = array_merge($urls, [
-        'https://s.webtrends.com',
-        'https://www.google-analytics.com',
-        'https://cdnjs.cloudflare.com',
-        'https://fonts.googleapis.com',
-        'https://maps.gstatic.com',
-        'https://maps.googleapis.com'
+        '//s.webtrends.com',
+        '//www.google-analytics.com',
+        '//cdnjs.cloudflare.com',
+        '//fonts.googleapis.com',
+        '//maps.gstatic.com',
+        '//maps.googleapis.com'
       ]);
 
       break;

--- a/wp-content/themes/access/archive-programs.php
+++ b/wp-content/themes/access/archive-programs.php
@@ -29,6 +29,27 @@ enqueue_script('main');
 enqueue_script('archive-programs');
 
 /**
+ * Manual DNS prefetch and preconnect headers
+ *
+ * @author NYC Opportunity
+ */
+
+add_filter('wp_resource_hints', function($urls, $relation_type) {
+  switch ($relation_type) {
+    case 'dns-prefetch':
+      $urls = array_merge($urls, [
+        'https://s.webtrends.com',
+        'https://www.google-analytics.com',
+        'https://cdnjs.cloudflare.com'
+      ]);
+
+      break;
+  }
+
+  return $urls;
+}, 10, 2);
+
+/**
  * Context
  */
 

--- a/wp-content/themes/access/archive-programs.php
+++ b/wp-content/themes/access/archive-programs.php
@@ -29,7 +29,11 @@ enqueue_script('main');
 enqueue_script('archive-programs');
 
 /**
- * Manual DNS prefetch and preconnect headers
+ * Manual DNS prefetch and preconnect headers that are not added through
+ * enqueueing functions above. DNS prefetch is added automatically. Preconnect
+ * headers always need to be added manually.
+ *
+ * @link https://developer.mozilla.org/en-US/docs/Web/Performance/dns-prefetch
  *
  * @author NYC Opportunity
  */
@@ -38,9 +42,9 @@ add_filter('wp_resource_hints', function($urls, $relation_type) {
   switch ($relation_type) {
     case 'dns-prefetch':
       $urls = array_merge($urls, [
-        'https://s.webtrends.com',
-        'https://www.google-analytics.com',
-        'https://cdnjs.cloudflare.com'
+        '//s.webtrends.com',
+        '//www.google-analytics.com',
+        '//cdnjs.cloudflare.com'
       ]);
 
       break;

--- a/wp-content/themes/access/index.php
+++ b/wp-content/themes/access/index.php
@@ -34,9 +34,14 @@ enqueue_script('main');
 
 add_filter('wp_resource_hints', function($urls, $relation_type) {
   switch ($relation_type) {
-    // case 'preconnect':
-    //   // Add preconnect to most critical assets here?
-    //   break;
+    case 'preconnect':
+      $urls = array_merge($urls, [
+        'https://cdnjs.cloudflare.com',
+        'https://maps.gstatic.com',
+        'https://maps.googleapis.com'
+      ]);
+
+      break;
 
     case 'dns-prefetch':
       $urls = array_merge($urls, [

--- a/wp-content/themes/access/index.php
+++ b/wp-content/themes/access/index.php
@@ -27,7 +27,11 @@ enqueue_inline('google-tag-manager');
 enqueue_script('main');
 
 /**
- * Manual DNS prefetch and preconnect headers
+ * Manual DNS prefetch and preconnect headers that are not added through
+ * enqueueing functions above. DNS prefetch is added automatically. Preconnect
+ * headers always need to be added manually.
+ *
+ * @link https://developer.mozilla.org/en-US/docs/Web/Performance/dns-prefetch
  *
  * @author NYC Opportunity
  */
@@ -36,9 +40,9 @@ add_filter('wp_resource_hints', function($urls, $relation_type) {
   switch ($relation_type) {
     case 'dns-prefetch':
       $urls = array_merge($urls, [
-        'https://s.webtrends.com',
-        'https://www.google-analytics.com',
-        'https://cdnjs.cloudflare.com'
+        '//s.webtrends.com',
+        '//www.google-analytics.com',
+        '//cdnjs.cloudflare.com'
       ]);
 
       break;

--- a/wp-content/themes/access/index.php
+++ b/wp-content/themes/access/index.php
@@ -34,15 +34,6 @@ enqueue_script('main');
 
 add_filter('wp_resource_hints', function($urls, $relation_type) {
   switch ($relation_type) {
-    case 'preconnect':
-      $urls = array_merge($urls, [
-        'https://cdnjs.cloudflare.com',
-        'https://maps.gstatic.com',
-        'https://maps.googleapis.com'
-      ]);
-
-      break;
-
     case 'dns-prefetch':
       $urls = array_merge($urls, [
         'https://s.webtrends.com',

--- a/wp-content/themes/access/index.php
+++ b/wp-content/themes/access/index.php
@@ -27,6 +27,31 @@ enqueue_inline('google-tag-manager');
 enqueue_script('main');
 
 /**
+ * Manual DNS prefetch and preconnect headers
+ *
+ * @author NYC Opportunity
+ */
+
+add_filter('wp_resource_hints', function($urls, $relation_type) {
+  switch ($relation_type) {
+    // case 'preconnect':
+    //   // Add preconnect to most critical assets here?
+    //   break;
+
+    case 'dns-prefetch':
+      $urls = array_merge($urls, [
+        'https://s.webtrends.com',
+        'https://www.google-analytics.com',
+        'https://cdnjs.cloudflare.com'
+      ]);
+
+      break;
+  }
+
+  return $urls;
+}, 10, 2);
+
+/**
  * Context
  */
 

--- a/wp-content/themes/access/screener-results.php
+++ b/wp-content/themes/access/screener-results.php
@@ -47,6 +47,39 @@ enqueue_script('main');
 enqueue_script('screener');
 
 /**
+ * Manual DNS prefetch and preconnect headers that are not added through
+ * enqueueing functions above. DNS prefetch is added automatically. Preconnect
+ * headers always need to be added manually.
+ *
+ * @link https://developer.mozilla.org/en-US/docs/Web/Performance/dns-prefetch
+ *
+ * @author NYC Opportunity
+ */
+
+add_filter('wp_resource_hints', function($urls, $relation_type) {
+  switch ($relation_type) {
+    case 'preconnect':
+      $urls = array_merge($urls, [
+        (defined('S3_UPLOADS_BUCKET'))
+          ? '//' . S3_UPLOADS_BUCKET . '.s3.amazonaws.com' : null
+      ]);
+
+      break;
+
+    case 'dns-prefetch':
+      $urls = array_merge($urls, [
+        '//s.webtrends.com',
+        '//www.google-analytics.com',
+        '//cdnjs.cloudflare.com'
+      ]);
+
+      break;
+  }
+
+  return $urls;
+}, 10, 2);
+
+/**
  * Context
  */
 

--- a/wp-content/themes/access/screener.php
+++ b/wp-content/themes/access/screener.php
@@ -32,6 +32,36 @@ enqueue_script('main');
 enqueue_script('screener');
 
 /**
+ * Manual DNS prefetch and preconnect headers
+ *
+ * @author NYC Opportunity
+ */
+
+add_filter('wp_resource_hints', function($urls, $relation_type) {
+  switch ($relation_type) {
+    case 'preconnect':
+      $urls = array_merge($urls, [
+        'https://gstatic.com',
+        'https://google.com'
+      ]);
+
+      break;
+
+    case 'dns-prefetch':
+      $urls = array_merge($urls, [
+        'https://s.webtrends.com',
+        'https://www.google-analytics.com',
+        'https://cdnjs.cloudflare.com'
+      ]);
+
+      break;
+  }
+
+  return $urls;
+}, 10, 2);
+
+
+/**
  * Context
  */
 

--- a/wp-content/themes/access/screener.php
+++ b/wp-content/themes/access/screener.php
@@ -32,7 +32,11 @@ enqueue_script('main');
 enqueue_script('screener');
 
 /**
- * Manual DNS prefetch and preconnect headers
+ * Manual DNS prefetch and preconnect headers that are not added through
+ * enqueueing functions above. DNS prefetch is added automatically. Preconnect
+ * headers always need to be added manually.
+ *
+ * @link https://developer.mozilla.org/en-US/docs/Web/Performance/dns-prefetch
  *
  * @author NYC Opportunity
  */
@@ -41,17 +45,17 @@ add_filter('wp_resource_hints', function($urls, $relation_type) {
   switch ($relation_type) {
     case 'preconnect':
       $urls = array_merge($urls, [
-        'https://gstatic.com',
-        'https://google.com'
+        '//www.gstatic.com',
+        '//www.google.com'
       ]);
 
       break;
 
     case 'dns-prefetch':
       $urls = array_merge($urls, [
-        'https://s.webtrends.com',
-        'https://www.google-analytics.com',
-        'https://cdnjs.cloudflare.com'
+        '//s.webtrends.com',
+        '//www.google-analytics.com',
+        '//cdnjs.cloudflare.com'
       ]);
 
       break;

--- a/wp-content/themes/access/search.php
+++ b/wp-content/themes/access/search.php
@@ -28,7 +28,11 @@ enqueue_inline('google-tag-manager');
 enqueue_script('main');
 
 /**
- * Manual DNS prefetch and preconnect headers
+ * Manual DNS prefetch and preconnect headers that are not added through
+ * enqueueing functions above. DNS prefetch is added automatically. Preconnect
+ * headers always need to be added manually.
+ *
+ * @link https://developer.mozilla.org/en-US/docs/Web/Performance/dns-prefetch
  *
  * @author NYC Opportunity
  */
@@ -37,9 +41,9 @@ add_filter('wp_resource_hints', function($urls, $relation_type) {
   switch ($relation_type) {
     case 'dns-prefetch':
       $urls = array_merge($urls, [
-        'https://s.webtrends.com',
-        'https://www.google-analytics.com',
-        'https://cdnjs.cloudflare.com'
+        '//s.webtrends.com',
+        '//www.google-analytics.com',
+        '//cdnjs.cloudflare.com'
       ]);
 
       break;

--- a/wp-content/themes/access/search.php
+++ b/wp-content/themes/access/search.php
@@ -28,6 +28,27 @@ enqueue_inline('google-tag-manager');
 enqueue_script('main');
 
 /**
+ * Manual DNS prefetch and preconnect headers
+ *
+ * @author NYC Opportunity
+ */
+
+add_filter('wp_resource_hints', function($urls, $relation_type) {
+  switch ($relation_type) {
+    case 'dns-prefetch':
+      $urls = array_merge($urls, [
+        'https://s.webtrends.com',
+        'https://www.google-analytics.com',
+        'https://cdnjs.cloudflare.com'
+      ]);
+
+      break;
+  }
+
+  return $urls;
+}, 10, 2);
+
+/**
  * Context
  */
 

--- a/wp-content/themes/access/single-location.php
+++ b/wp-content/themes/access/single-location.php
@@ -29,19 +29,37 @@ enqueue_script('main');
 enqueue_script('single-location');
 
 /**
- * Manually prefetch asset DNS
+ * Manual DNS prefetch and preconnect headers
+ *
  * @author NYC Opportunity
  */
 
-add_action('wp_head', function(){
-  echo '<meta http-equiv="x-dns-prefetch-control" content="on">
-  <link rel="preconnect" href="https://maps.googleapis.com" crossorigin>
-  <link rel="dns-prefetch" href="https://maps.googleapis.com" >
-  <link rel="preconnect" href="https://maps.gstatic.com" crossorigin>
-  <link rel="dns-prefetch" href="https://maps.gstatic.com" >
-  <link rel="preconnect" href="https://fonts.gstatic.com/" crossorigin>
-  <link rel="dns-prefetch" href="https://fonts.gstatic.com" >';
-}, 0);
+add_filter('wp_resource_hints', function($urls, $relation_type) {
+  switch ($relation_type) {
+    case 'preconnect':
+      $urls = array_merge($urls, [
+        'https://cdnjs.cloudflare.com',
+        'https://maps.gstatic.com',
+        'https://maps.googleapis.com'
+      ]);
+
+      break;
+
+    case 'dns-prefetch':
+      $urls = array_merge($urls, [
+        'https://s.webtrends.com',
+        'https://www.google-analytics.com',
+        'https://cdnjs.cloudflare.com',
+        'https://fonts.googleapis.com',
+        'https://maps.gstatic.com',
+        'https://maps.googleapis.com'
+      ]);
+
+      break;
+  }
+
+  return $urls;
+}, 10, 2);
 
 /**
  * Context

--- a/wp-content/themes/access/single-location.php
+++ b/wp-content/themes/access/single-location.php
@@ -29,7 +29,11 @@ enqueue_script('main');
 enqueue_script('single-location');
 
 /**
- * Manual DNS prefetch and preconnect headers
+ * Manual DNS prefetch and preconnect headers that are not added through
+ * enqueueing functions above. DNS prefetch is added automatically. Preconnect
+ * headers always need to be added manually.
+ *
+ * @link https://developer.mozilla.org/en-US/docs/Web/Performance/dns-prefetch
  *
  * @author NYC Opportunity
  */
@@ -38,21 +42,21 @@ add_filter('wp_resource_hints', function($urls, $relation_type) {
   switch ($relation_type) {
     case 'preconnect':
       $urls = array_merge($urls, [
-        'https://cdnjs.cloudflare.com',
-        'https://maps.gstatic.com',
-        'https://maps.googleapis.com'
+        '//cdnjs.cloudflare.com',
+        '//maps.gstatic.com',
+        '//maps.googleapis.com'
       ]);
 
       break;
 
     case 'dns-prefetch':
       $urls = array_merge($urls, [
-        'https://s.webtrends.com',
-        'https://www.google-analytics.com',
-        'https://cdnjs.cloudflare.com',
-        'https://fonts.googleapis.com',
-        'https://maps.gstatic.com',
-        'https://maps.googleapis.com'
+        '//s.webtrends.com',
+        '//www.google-analytics.com',
+        '//cdnjs.cloudflare.com',
+        '//fonts.googleapis.com',
+        '//maps.gstatic.com',
+        '//maps.googleapis.com'
       ]);
 
       break;

--- a/wp-content/themes/access/single-location.php
+++ b/wp-content/themes/access/single-location.php
@@ -29,6 +29,21 @@ enqueue_script('main');
 enqueue_script('single-location');
 
 /**
+ * Manually prefetch asset DNS
+ * @author NYC Opportunity
+ */
+
+add_action('wp_head', function(){
+  echo '<meta http-equiv="x-dns-prefetch-control" content="on">
+  <link rel="preconnect" href="https://maps.googleapis.com" crossorigin>
+  <link rel="dns-prefetch" href="https://maps.googleapis.com" >
+  <link rel="preconnect" href="https://maps.gstatic.com" crossorigin>
+  <link rel="dns-prefetch" href="https://maps.gstatic.com" >
+  <link rel="preconnect" href="https://fonts.gstatic.com/" crossorigin>
+  <link rel="dns-prefetch" href="https://fonts.gstatic.com" >';
+}, 0);
+
+/**
  * Context
  */
 

--- a/wp-content/themes/access/single-page-legacy.php
+++ b/wp-content/themes/access/single-page-legacy.php
@@ -29,6 +29,27 @@ enqueue_inline('google-translate-element');
 enqueue_script('main');
 
 /**
+ * Manual DNS prefetch and preconnect headers
+ *
+ * @author NYC Opportunity
+ */
+
+add_filter('wp_resource_hints', function($urls, $relation_type) {
+  switch ($relation_type) {
+    case 'dns-prefetch':
+      $urls = array_merge($urls, [
+        'https://s.webtrends.com',
+        'https://www.google-analytics.com',
+        'https://cdnjs.cloudflare.com'
+      ]);
+
+      break;
+  }
+
+  return $urls;
+}, 10, 2);
+
+/**
  * Context
  */
 

--- a/wp-content/themes/access/single-page-legacy.php
+++ b/wp-content/themes/access/single-page-legacy.php
@@ -29,18 +29,30 @@ enqueue_inline('google-translate-element');
 enqueue_script('main');
 
 /**
- * Manual DNS prefetch and preconnect headers
+ * Manual DNS prefetch and preconnect headers that are not added through
+ * enqueueing functions above. DNS prefetch is added automatically. Preconnect
+ * headers always need to be added manually.
+ *
+ * @link https://developer.mozilla.org/en-US/docs/Web/Performance/dns-prefetch
  *
  * @author NYC Opportunity
  */
 
 add_filter('wp_resource_hints', function($urls, $relation_type) {
   switch ($relation_type) {
+    case 'preconnect':
+      $urls = array_merge($urls, [
+        (defined('S3_UPLOADS_BUCKET'))
+          ? '//' . S3_UPLOADS_BUCKET . '.s3.amazonaws.com' : null
+      ]);
+
+      break;
+
     case 'dns-prefetch':
       $urls = array_merge($urls, [
-        'https://s.webtrends.com',
-        'https://www.google-analytics.com',
-        'https://cdnjs.cloudflare.com'
+        '//s.webtrends.com',
+        '//www.google-analytics.com',
+        '//cdnjs.cloudflare.com'
       ]);
 
       break;

--- a/wp-content/themes/access/single-programs.php
+++ b/wp-content/themes/access/single-programs.php
@@ -30,7 +30,11 @@ enqueue_script('main');
 enqueue_script('single-programs');
 
 /**
- * Manual DNS prefetch and preconnect headers
+ * Manual DNS prefetch and preconnect headers that are not added through
+ * enqueueing functions above. DNS prefetch is added automatically. Preconnect
+ * headers always need to be added manually.
+ *
+ * @link https://developer.mozilla.org/en-US/docs/Web/Performance/dns-prefetch
  *
  * @author NYC Opportunity
  */
@@ -39,16 +43,17 @@ add_filter('wp_resource_hints', function($urls, $relation_type) {
   switch ($relation_type) {
     case 'preconnect':
       $urls = array_merge($urls, [
-        'access-nyc-s3-uploads.s3.amazonaws.com',
+        (defined('S3_UPLOADS_BUCKET'))
+          ? '//' . S3_UPLOADS_BUCKET . '.s3.amazonaws.com' : null
       ]);
 
       break;
 
     case 'dns-prefetch':
       $urls = array_merge($urls, [
-        'https://s.webtrends.com',
-        'https://www.google-analytics.com',
-        'https://cdnjs.cloudflare.com'
+        '//s.webtrends.com',
+        '//www.google-analytics.com',
+        '//cdnjs.cloudflare.com'
       ]);
 
       break;

--- a/wp-content/themes/access/single-programs.php
+++ b/wp-content/themes/access/single-programs.php
@@ -30,6 +30,34 @@ enqueue_script('main');
 enqueue_script('single-programs');
 
 /**
+ * Manual DNS prefetch and preconnect headers
+ *
+ * @author NYC Opportunity
+ */
+
+add_filter('wp_resource_hints', function($urls, $relation_type) {
+  switch ($relation_type) {
+    case 'preconnect':
+      $urls = array_merge($urls, [
+        'access-nyc-s3-uploads.s3.amazonaws.com',
+      ]);
+
+      break;
+
+    case 'dns-prefetch':
+      $urls = array_merge($urls, [
+        'https://s.webtrends.com',
+        'https://www.google-analytics.com',
+        'https://cdnjs.cloudflare.com'
+      ]);
+
+      break;
+  }
+
+  return $urls;
+}, 10, 2);
+
+/**
  * Context
  */
 

--- a/wp-content/themes/access/singular.php
+++ b/wp-content/themes/access/singular.php
@@ -29,6 +29,27 @@ enqueue_inline('google-translate-element');
 enqueue_script('main');
 
 /**
+ * Manual DNS prefetch and preconnect headers
+ *
+ * @author NYC Opportunity
+ */
+
+add_filter('wp_resource_hints', function($urls, $relation_type) {
+  switch ($relation_type) {
+    case 'dns-prefetch':
+      $urls = array_merge($urls, [
+        'https://s.webtrends.com',
+        'https://www.google-analytics.com',
+        'https://cdnjs.cloudflare.com'
+      ]);
+
+      break;
+  }
+
+  return $urls;
+}, 10, 2);
+
+/**
  * Context
  */
 

--- a/wp-content/themes/access/singular.php
+++ b/wp-content/themes/access/singular.php
@@ -29,18 +29,30 @@ enqueue_inline('google-translate-element');
 enqueue_script('main');
 
 /**
- * Manual DNS prefetch and preconnect headers
+ * Manual DNS prefetch and preconnect headers that are not added through
+ * enqueueing functions above. DNS prefetch is added automatically. Preconnect
+ * headers always need to be added manually.
+ *
+ * @link https://developer.mozilla.org/en-US/docs/Web/Performance/dns-prefetch
  *
  * @author NYC Opportunity
  */
 
 add_filter('wp_resource_hints', function($urls, $relation_type) {
   switch ($relation_type) {
+    case 'preconnect':
+      $urls = array_merge($urls, [
+        (defined('S3_UPLOADS_BUCKET'))
+          ? '//' . S3_UPLOADS_BUCKET . '.s3.amazonaws.com' : null
+      ]);
+
+      break;
+
     case 'dns-prefetch':
       $urls = array_merge($urls, [
-        'https://s.webtrends.com',
-        'https://www.google-analytics.com',
-        'https://cdnjs.cloudflare.com'
+        '//s.webtrends.com',
+        '//www.google-analytics.com',
+        '//cdnjs.cloudflare.com'
       ]);
 
       break;

--- a/wp-content/themes/access/views/partials/head.twig
+++ b/wp-content/themes/access/views/partials/head.twig
@@ -16,6 +16,13 @@
 <link rel="icon" type="image/png" sizes="96x96" href="{{ theme.path }}/assets/img/favicon-96x96.png">
 <link rel="icon" type="image/png" sizes="16x16" href="{{ theme.path }}/assets/img/favicon-16x16.png">
 
+<link rel="preconnect" href="https://maps.googleapis.com" crossorigin>
+<link rel="dns-prefetch" href="https://maps.googleapis.com" >
+<link rel="preconnect" href="https://maps.gstatic.com" crossorigin>
+<link rel="dns-prefetch" href="https://maps.gstatic.com" >
+<link rel="preconnect" href="https://fonts.gstatic.com/" crossorigin>
+<link rel="dns-prefetch" href="https://fonts.gstatic.com" >
+
 <meta name="msapplication-TileColor" content="#112E51">
 <meta name="msapplication-TileImage" content="{{ theme.path }}/assets/img/ms-icon-144x144.png">
 

--- a/wp-content/themes/access/views/partials/head.twig
+++ b/wp-content/themes/access/views/partials/head.twig
@@ -16,13 +16,6 @@
 <link rel="icon" type="image/png" sizes="96x96" href="{{ theme.path }}/assets/img/favicon-96x96.png">
 <link rel="icon" type="image/png" sizes="16x16" href="{{ theme.path }}/assets/img/favicon-16x16.png">
 
-<link rel="preconnect" href="https://maps.googleapis.com" crossorigin>
-<link rel="dns-prefetch" href="https://maps.googleapis.com" >
-<link rel="preconnect" href="https://maps.gstatic.com" crossorigin>
-<link rel="dns-prefetch" href="https://maps.gstatic.com" >
-<link rel="preconnect" href="https://fonts.gstatic.com/" crossorigin>
-<link rel="dns-prefetch" href="https://fonts.gstatic.com" >
-
 <meta name="msapplication-TileColor" content="#112E51">
 <meta name="msapplication-TileImage" content="{{ theme.path }}/assets/img/ms-icon-144x144.png">
 


### PR DESCRIPTION
consider pairing dns-prefetch with the preconnect hint. While
dns-prefetch only performs a DNS lookup, preconnect establishes a
connection to a server. This process includes DNS resolution, as well as
establishing the TCP connection, and performing the TLS handshake—if a
site is served over HTTPS. Combining the two provides an opportunity to
further reduce the perceived latency of cross-origin requests. You can
safely use them together

Note: If a page needs to make connections to many third-party domains,
preconnecting them all is counterproductive. The preconnect hint is best
used for only the most critical connections.
For the others, just use <link rel="dns-prefetch">
to save time on the first step — the DNS lookup.