### PR TITLE
Retrieve data from locations endpoint

### DIFF
--- a/wp-content/themes/access/views/locations/archive.twig
+++ b/wp-content/themes/access/views/locations/archive.twig
@@ -43,7 +43,7 @@
                   <li class="c-filter-multi__item-group-subitem">
                     <label class="checkbox">
                       <input type="checkbox" value="{{ program.uid }}" class="js-map-filter-program-input" tabindex="-1">
-                      <span class="checkbox__label text-small font-normal">{{ program.post_title }}</span>
+                      <span class="checkbox__label text-small font-normal">{{ program.program_name }}</span>
                     </label>
                   </li>
                   {% endfor %}


### PR DESCRIPTION
When navigating to the locations endpoint an empty array was being
returned. The issue came from the implementation of the location
endpoint in the register-rest-routes.php file.

I decided to use the WP_QUERY instead of the get_posts function. Thus,
helped in retrieving the locations posts. Also, a configuration on the
WPML will need to be changed from the CMS.  WPML -> settings -> Post
Types Translations -> Locations -> Translatable - use translation if
available or fallback to default language. The settings change will
default to english if no translation is provided.

I also set up a `program_name` attribute in the location `post` object
to be able to display the programs name in the language ACCESS is being
navigated on.

This was a fun week trying to make this bug happen. Huge shout out to
@kimpenguin and @devowhippit for the support fixing this.