### PR TITLE
Fix for Dockerfile smell DL3009

### DIFF
--- a/wp-content/plugins/redis-cache/dependencies/colinmollenhour/credis/testenv/env/php-7.2/Dockerfile
+++ b/wp-content/plugins/redis-cache/dependencies/colinmollenhour/credis/testenv/env/php-7.2/Dockerfile
@@ -3,7 +3,9 @@ ENV phpunit_verison 7.5
 ENV redis_version 6.0.8
 
 RUN apt-get update && \
-    apt-get install -y wget libssl-dev
+    apt-get install -y wget libssl-dev && \ 
+    apt-get clean && \
+    rm -rf /var/lib/apt/lists/*
 
 RUN wget https://phar.phpunit.de/phpunit-${phpunit_verison}.phar && \
     chmod +x phpunit-${phpunit_verison}.phar && \


### PR DESCRIPTION
Hi!
The Dockerfile placed at "wp-content/plugins/redis-cache/dependencies/colinmollenhour/credis/testenv/env/php-7.2/Dockerfile" contains the best practice violation [DL3009](https://github.com/hadolint/hadolint/wiki/DL3009) detected by the [hadolint](https://github.com/hadolint/hadolint) tool.

The smell DL3009 occurs when the apt tool is used to install packages without wiping the cache and source lists.
In this pull request, we propose a fix for that smell generated by our fixing tool. We manually checked that the patch is correct before opening the pull request.
To fix this smell, specifically, the instructions to clean up the apt cache and remove the /var/lib/apt/lists have been added. This helps keep the image size down.

This change is only aimed at fixing that specific smell. In the case the fix is not valid or useful, please briefly indicate the reason along with suggestions for possible improvements.

Thanks in advance.