### PR TITLE
check get_the_terms result before array_merge

### DIFF
--- a/wp-content/mu-plugins/rest-prepare-posts/RestPreparePosts.php
+++ b/wp-content/mu-plugins/rest-prepare-posts/RestPreparePosts.php
@@ -95,7 +95,12 @@ class RestPreparePosts {
     $terms = array();
 
     foreach (get_taxonomies($this->tax_options, 'objects') as $taxonomy) {
-      $terms = array_merge($terms, get_the_terms($id, $taxonomy->name));
+      $taxonomy_terms = get_the_terms($id, $taxonomy->name);
+
+      // get_the_terms returns false if there are no terms
+      if ($taxonomy_terms !== false) {
+        $terms = array_merge($terms, $taxonomy_terms);
+      }
     }
 
     return $terms;


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved reliability of term handling in posts, ensuring better stability when terms are not available.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->