### PR TITLE
removed accordion and here are your options text

### DIFF
--- a/wp-content/themes/access/views/programs/how-to-apply.twig
+++ b/wp-content/themes/access/views/programs/how-to-apply.twig
@@ -1,8 +1,6 @@
 <section id="how-to-apply" data-step="how-to-apply" class="outline-none active hidden:overflow print:active w-full" aria-hidden="false">
   <header>
     <h3>{{ stepNumber }}. {{ __('How to apply', 'accessnyc-program-detail') }}</h3>
-
-    <h4 class="font-normal">{{ __('Here are your options.', 'accessnyc-program-detail') }}</h4>
   </header>
 
   {# {% set sections = [
@@ -85,7 +83,28 @@
       } %}
     {% endif %}
 
-    {% include 'components/accordion.twig' with {this: this} only %}
+    <article id="{{ this.id }}" class="c-accordion">
+      <header class="c-accordion__header color-dark-background">
+        <p id="aria-lb-{{ this.id }}">
+          {{ this.header }}
+        </p>
+      </header>
+
+      <div class="c-accordion__body color-mid-background text-small screen-tablet:text-normal print:active hidden:overflow animated">
+        <div class="c-accordion__padding">
+          {{ this.body }}
+
+          {% if this.cta %}
+          <p class="print:hidden">
+            {% if this.itemtype %}<span class="hidden" aria-hidden="true">{{ this.cta.href }}</span>{% endif %}
+            <a class="btn btn-secondary btn-next text-small" href="{{ this.cta.href }}" {% if this.cta.target %}target="{{ this.cta.target }}"{% endif %} {% if this.cta.rel %}rel="{{ this.cta.rel }}"{% endif %}>
+              {{ this.cta.text }}
+            </a>
+          </p>
+          {% endif %}
+        </div>
+      </div>
+    </article>
   {% endfor %}
 
   <div class="c-alert-box bg-status-info print:hidden">


### PR DESCRIPTION
For “how to apply” section on program page, Remove accordion link ("hide this list") and keep these expanded. Delete “Here are your options” body text.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Introduced an enhanced accordion structure for the "How to Apply" section, improving content presentation and accessibility.
	- Added a conditional call-to-action link that is hidden in print view but accessible in other contexts.
  
- **Improvements**
	- Streamlined the header section for better semantic organization and user experience.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->