### PR TITLE
Revert "assign A/B variant in program guide"

### DIFF
--- a/wp-content/themes/access/controllers/site.php
+++ b/wp-content/themes/access/controllers/site.php
@@ -108,6 +108,20 @@ class Site extends TimberSite {
     $context['is_print'] = get_query_var('print', false); // Print view
     $context['a_b_testing_on'] = filter_var(get_field('field_6790152da121b', 'option'), FILTER_VALIDATE_BOOLEAN);
 
+    // If A/B testing is on, add the A/B test variant to the cookies and the context
+    // The variant cookie is stored for 30 days
+    if ($context['a_b_testing_on']) {
+      if (isset($_COOKIE['ab_test_variant']) and (
+          $_COOKIE['ab_test_variant'] == 'a'
+          or $_COOKIE['ab_test_variant'] == 'b')) { // Variant cookie must be a valid value
+        $context['variant'] = $_COOKIE['ab_test_variant'];
+      } else {
+        $variant = rand(0, 1) ? 'a' : 'b';
+        setcookie('ab_test_variant', $variant, time() + (DAY_IN_SECONDS * 30), COOKIEPATH, COOKIE_DOMAIN);
+        $context['variant'] = $variant;
+      }
+    }
+
     /**
      * Get the default page meta description for the page
      */

--- a/wp-content/themes/access/single-programs.php
+++ b/wp-content/themes/access/single-programs.php
@@ -73,20 +73,6 @@ $program = new Controller\Programs();
 
 $context = Timber::get_context();
 
-// If A/B testing is on, add the A/B test variant to the cookies and the context
-// The variant cookie is stored for 30 days
-if ($context['a_b_testing_on']) {
-  if (isset($_COOKIE['ab_test_variant']) and (
-      $_COOKIE['ab_test_variant'] == 'a'
-      or $_COOKIE['ab_test_variant'] == 'b')) { // Variant cookie must be a valid value
-    $context['variant'] = $_COOKIE['ab_test_variant'];
-  } else {
-    $variant = rand(0, 1) ? 'a' : 'b';
-    setcookie('ab_test_variant', $variant, time() + (DAY_IN_SECONDS * 30), COOKIEPATH, COOKIE_DOMAIN);
-    $context['variant'] = $variant;
-  }
-}
-
 // If A/B testing is on, use the Javascript script that matches the variant
 if ($context['a_b_testing_on'] && $context['variant'] == 'b') {
   enqueue_script('single-programs-b');


### PR DESCRIPTION
This may have caused A/B testing to fail on dev/staging/production (but continue to work locally). 