### PR TITLE
allow homepage touts to be empty

### DIFF
--- a/wp-content/themes/access/index.php
+++ b/wp-content/themes/access/index.php
@@ -100,9 +100,11 @@ if (is_home()) {
    * @author NYC Opportunity
    */
 
-  $context['homepage_touts_latest_update'] = max(array_map(function($post) {
-    return $post->post_modified;
-  }, $context['homepage_touts']));
+  if (!empty($context['homepage_touts'])) {
+    $context['homepage_touts_latest_update'] = max(array_map(function($post) {
+      return $post->post_modified;
+    }, $context['homepage_touts']));
+  }
 
   // Alert
   $context['homepage_alert'] = Timber::get_post(array(


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
	- Improved stability by adding a safeguard for displaying the homepage’s latest update. Now, the update calculation only runs when relevant information is available, preventing potential errors when the data set is empty.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->