### PR TITLE
remove email sending from front end

### DIFF
--- a/wp-content/themes/access/views/programs/single.twig
+++ b/wp-content/themes/access/views/programs/single.twig
@@ -176,7 +176,7 @@
                   template: 'programs'
                 }} only %}
 
-                {% include 'components/share-form.twig' with {this: {
+                {# {% include 'components/share-form.twig' with {this: {
                   type: 'email',
                   button: __('Email', 'accessnyc-program-detail'),
                   placeholder: __('Email address', 'accessnyc-program-detail'),
@@ -186,7 +186,7 @@
                   hash: post.share_hash,
                   program_name: post.program_name,
                   template: 'programs'
-                }} only %}
+                }} only %} #}
               </div>
 
               <div class="mt-3 screen-tablet:m-0 hidden" aria-hidden="true" id="aria-db-share-disclaimer">

--- a/wp-content/themes/access/views/screener/results.twig
+++ b/wp-content/themes/access/views/screener/results.twig
@@ -57,7 +57,7 @@
           template: 'screener-results'
         }} only %}
 
-        {% include 'components/share-form.twig' with {this: {
+        {# {% include 'components/share-form.twig' with {this: {
           class: 'mb-2',
           type: 'email',
           button: __('Email', 'accessnyc-results'),
@@ -68,7 +68,7 @@
           hash: shareHash,
           guid: getParams.guid,
           template: 'screener-results'
-        }} only %}
+        }} only %} #}
 
         <div class="hidden" aria-hidden="true" id="aria-db-share-disclaimer">
           {% include 'components/disclaimer-small.twig' %}


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Refactor**
  - Disabled the email share form on program and screener results pages; only the telephone and SMS share forms remain visible.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->