### PR TITLE
prevent example email domains and phone numbers

### DIFF
--- a/wp-content/mu-plugins/wp-send-me-nyc/EmailMe.php
+++ b/wp-content/mu-plugins/wp-send-me-nyc/EmailMe.php
@@ -185,6 +185,10 @@ class EmailMe extends ContactMe {
       $this->failure(2, 'Invalid email address. Please provide a valid email');
 
       return false;
+    } elseif (str_ends_with($addr, 'example.com')){
+      $this->failure(2, 'Invalid email address. Please provide a valid email');
+
+      return false;
     }
 
     return true;

--- a/wp-content/mu-plugins/wp-send-me-nyc/README.md
+++ b/wp-content/mu-plugins/wp-send-me-nyc/README.md
@@ -145,7 +145,7 @@ Amazon SES Service email send action | `email_send`
 
 Name       | Value Description
 -----------|-
-`to`       | A valid email address (validates against the [`FILTER_VALIDATE_EMAIL`](https://www.php.net/manual/en/filter.filters.validate.php) validate filter) or phone number (10 digit number including area code), depending on the action.
+`to`       | A valid email address (validates against the [`FILTER_VALIDATE_EMAIL`](https://www.php.net/manual/en/filter.filters.validate.php) validate filter) or phone number (10 digit number including area code), depending on the action. Example email addresses and phone numbers (such as the example.com domain or 555 area code) are not allowed. 
 `action`   | The Ajax action callback name; `sms_send` or `email_send`.
 `url`      | The URL to be shared with the recipient, this is what replaces the contents of the `{{ BITLY_URL }}` and `{{ URL }}` in the post content.
 `template` | The slug of the SMNYC Post to use as the template for sms or email content.

--- a/wp-content/mu-plugins/wp-send-me-nyc/SmsMe.php
+++ b/wp-content/mu-plugins/wp-send-me-nyc/SmsMe.php
@@ -127,8 +127,12 @@ class SmsMe extends ContactMe {
       $this->failure(2, 'Invalid phone number. Please provide 10-digit number with area code');
 
       return false;
-    }
+    } elseif (substr($to, 0, 3) == '555') { // 555 is a sample area code
+      $this->failure(2, 'Invalid phone number. Please provide 10-digit number with area code');
 
+      return false;
+    }
+ 
     // assume longer numbers have country code specified
     return true;
   }


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
	- Improved validation to reject email addresses ending with "example.com" and phone numbers starting with "555" as invalid recipients.

- **Documentation**
	- Updated documentation to clarify that example email addresses and phone numbers (such as those using "example.com" or the "555" area code) are not allowed.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->