### PR TITLE
Add rate limiting to text and email

### DIFF
--- a/wp-content/mu-plugins/wp-send-me-nyc/README.md
+++ b/wp-content/mu-plugins/wp-send-me-nyc/README.md
@@ -235,7 +235,7 @@ This action is fired after a message is sent successfully.
 #### Examples
 
 ```php
-add_action('smnyc_message_sent', function($type, $to, $uid, $url, $message) {
+add_action('smnyc_message_sent', function($type, $to, $uid, $url, $message, $ip_address) {
   // Successful message sent handler
 }, 10, 5);
 ```

--- a/wp-content/mu-plugins/wp-send-me-nyc/SmsMe.php
+++ b/wp-content/mu-plugins/wp-send-me-nyc/SmsMe.php
@@ -70,6 +70,10 @@ class SmsMe extends ContactMe {
    * @param   String  $msg  The message to send.
    */
   protected function send($to, $msg) {
+    if ($msg == null || empty($msg)) {
+      return $this->failure(3, 'Message cannot be empty');
+    }
+
     try {
       $user = get_option($this->info()['option_prefix'] . 'user');
       $apiKeySid = get_option($this->info()['option_prefix'] . 'api_key_sid');

--- a/wp-content/mu-plugins/wp-stat-collector.php
+++ b/wp-content/mu-plugins/wp-stat-collector.php
@@ -46,19 +46,21 @@ add_action('statc_register', function($statc) {
   /**
    * Hook for the Stat Collector action for saving the email content to the DB
    *
-   * @param   String  $type  email/sms/whatever the class type is
-   * @param   String  $to    The number/email sent to
-   * @param   String  $uid   The GUID of the results
-   * @param   String  $url   The main url shared
-   * @param   String  $msg   The body of the message
+   * @param   String  $type         email/sms/whatever the class type is
+   * @param   String  $to           The number/email sent to
+   * @param   String  $uid          The GUID of the results
+   * @param   String  $url          The main url shared
+   * @param   String  $msg          The body of the message
+   * @param   String  $ip_address   IP address of the sender
    */
-  add_action('smnyc_message_sent', function($type, $to, $uid, $url = null, $message = null) use ($statc) {
+  add_action('smnyc_message_sent', function($type, $to, $uid, $url = null, $message = null, $ip_address = null) use ($statc) {
     $statc->collect('messages', [
       'uid' => $uid,
       'msg_type' => strtolower($type),
       'address' => $to,
       'url' => $url,
-      'message' => $message
+      'message' => $message,
+      'ip_address' => $ip_address
     ]);
   }, $statc->settings->priority, 5);
 
@@ -80,6 +82,7 @@ add_action('statc_bootstrap', function($db) {
       date DATETIME DEFAULT NOW(),
       url VARCHAR(512) DEFAULT NULL,
       message TEXT DEFAULT NULL,
+      ip_address VARCHAR(255) DEFAULT NULL,
       PRIMARY KEY(id)
     ) ENGINE=InnoDB'
   );

--- a/wp-content/mu-plugins/wp-stat-collector.php
+++ b/wp-content/mu-plugins/wp-stat-collector.php
@@ -62,7 +62,7 @@ add_action('statc_register', function($statc) {
       'message' => $message,
       'ip_address' => $ip_address
     ]);
-  }, $statc->settings->priority, 5);
+  }, $statc->settings->priority, 6);
 
   return true;
 });


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added rate limiting to contact form submissions, restricting to 15 submissions per hour per IP address and recipient.
  - Sender's IP address is now captured and stored with each message for enhanced tracking.

- **Bug Fixes**
  - Submissions with empty messages are now prevented, displaying an appropriate error message.

- **Documentation**
  - Updated usage examples and documentation to reflect the inclusion of the sender's IP address in message handling and logging.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->