### PR TITLE
Remove unused footer section on homepage

### DIFF
--- a/wp-content/mu-plugins/register-menus.php
+++ b/wp-content/mu-plugins/register-menus.php
@@ -11,7 +11,6 @@ add_action('init', function() {
       'header-menu' => __('Nav bar'),
       'header-menu-b' => __('Nav bar [variant B for A/B testing]'),
       'get-help-now' => __('Footer Menu 1 [left]'),
-      'for-caseworkers' => __('Footer Menu 2 [left]'),
       'programs' => __('Footer Menu 3 [center]'),
       'about-access-nyc' => __('Footer Menu 4 [right]'),
     )

--- a/wp-content/themes/access/controllers/site.php
+++ b/wp-content/themes/access/controllers/site.php
@@ -94,8 +94,6 @@ class Site extends TimberSite {
 
     $context['footer_get_help_now_menu'] = new TimberMenu('get-help-now');
 
-    $context['footer_for_caseworkers_menu'] = new TimberMenu('for-caseworkers');
-
     $context['footer_programs_menu'] = new TimberMenu('programs');
 
     $context['footer_about_access_nyc_menu'] = new TimberMenu('about-access-nyc');

--- a/wp-content/themes/access/views/objects/footer.twig
+++ b/wp-content/themes/access/views/objects/footer.twig
@@ -14,19 +14,6 @@
         </li>
       {% endfor %}
       </ul>
-      <div class="type-h3 text-blue-dark">{{ footer_for_caseworkers_menu.name }}</div>
-      <ul>
-        {% for m in footer_for_caseworkers_menu.get_items %}
-          <li>
-            <a href="{{ m.link }}"
-              {% if m.attr_title %}title="{{ m.attr_title }}"{% else %}title="{{ m.title }}"{% endif %}
-              {% if m.target %}target="{{ m.target }}"{% endif %}
-              {% if m.xfn %}rel="{{ m.xfn }}"{% endif %}>
-              {{ m.title }}
-            </a>
-          </li>
-        {% endfor %}
-      </ul>
     </li>
     <li class="o-footer__column-middle">
       <div class="type-h3 text-blue-dark">{{ footer_programs_menu.name }}</div>
@@ -52,7 +39,6 @@
           <use xlink:href="#icon-logo-full"></use>
         </svg>
       </div>
-
       <ul>
         {% for m in footer_about_access_nyc_menu.get_items %}
           <li>


### PR DESCRIPTION
This footer section on the ACCESS NYC homepage was previously used to display the `for-caseworkers` menu items, which no longer exist. We are removing this footer section for now as there are no plans to fill it with a new menu.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Removed the "For Caseworkers" menu from the footer.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->