### PR TITLE
Remove jump links in program page history

### DIFF
--- a/wp-content/themes/access/src/js/single-programs.js
+++ b/wp-content/themes/access/src/js/single-programs.js
@@ -137,33 +137,11 @@ import 'modules/share-form';
             })
         }
 
-        // Adjust scroll when clicking jump links
-        document.querySelectorAll(".top-nav-link").forEach((link) => {
+        function handleNavClick(link, extraCallback) {
             link.addEventListener("click", (e) => {
-                e.preventDefault(); // Prevent default jump behavior
+                e.preventDefault();
 
-                const navSize = getNavSize();
-                const targetId = link.getAttribute("href").substring(1);
-                const targetElement = document.getElementById(targetId);
-
-                if (targetElement) {
-                    const targetPosition = targetElement.getBoundingClientRect().top + window.scrollY - navSize;
-                    window.scrollTo({
-                        top: targetPosition
-                    });
-
-                    centerActiveLinkIfScrollable();
-                }
-
-                history.replaceState(null, "", `#${targetId}`);
-            });
-        });
-
-        document.querySelectorAll(".side-nav-link").forEach((link) => {
-            link.addEventListener("click", (e) => {
-                e.preventDefault(); // Prevent default jump behavior
-                
-                const navSize = getNavSize();
+                const navSize = getNavSize().size;
                 const targetId = link.getAttribute("href").substring(1);
                 const targetElement = document.getElementById(targetId);
 
@@ -179,7 +157,23 @@ import 'modules/share-form';
                 }
 
                 history.replaceState(null, "", `#${targetId}`);
+
+                if (extraCallback) {
+                    extraCallback();
+                }
             });
+        }
+
+        // Adjust scroll when clicking jump links on top navigation bar
+        document.querySelectorAll(".top-nav-link").forEach((link) => {
+            handleNavClick(link, () => {
+                centerActiveLinkIfScrollable();
+            });
+        });
+
+        // Adjust scroll when clicking jump links on side navigation bar
+        document.querySelectorAll(".side-nav-link").forEach((link) => {
+            handleNavClick(link);
         });
 
     });

--- a/wp-content/themes/access/src/js/single-programs.js
+++ b/wp-content/themes/access/src/js/single-programs.js
@@ -106,7 +106,7 @@ import 'modules/share-form';
 
                 // Add the hash to the URL unless the user is at the top of the page
                 if (window.scrollY > navBottom) {
-                    history.pushState(null, "", `#${topSection.id}`);
+                    history.replaceState(null, "", `#${topSection.id}`);
                 }
             }
         };
@@ -140,24 +140,45 @@ import 'modules/share-form';
         // Adjust scroll when clicking jump links
         document.querySelectorAll(".top-nav-link").forEach((link) => {
             link.addEventListener("click", (e) => {
-                const { bottom: navBottom, size: navSize } = getNavSize();
+                e.preventDefault(); // Prevent default jump behavior
 
-                if (navBottom > 0) {
-                    e.preventDefault(); // Prevent default jump behavior
-                    const targetId = link.getAttribute("href").substring(1);
-                    const targetElement = document.getElementById(targetId);
+                const navSize = getNavSize();
+                const targetId = link.getAttribute("href").substring(1);
+                const targetElement = document.getElementById(targetId);
 
-                    if (targetElement) {
-                        const targetPosition = targetElement.getBoundingClientRect().top + window.scrollY - navSize;
-                        window.scrollTo({
-                            top: targetPosition
-                        });
+                if (targetElement) {
+                    const targetPosition = targetElement.getBoundingClientRect().top + window.scrollY - navSize;
+                    window.scrollTo({
+                        top: targetPosition
+                    });
 
-                        centerActiveLinkIfScrollable();
-                    }
-
-                    history.pushState(null, "", `#${targetId}`);
+                    centerActiveLinkIfScrollable();
                 }
+
+                history.replaceState(null, "", `#${targetId}`);
+            });
+        });
+
+        document.querySelectorAll(".side-nav-link").forEach((link) => {
+            link.addEventListener("click", (e) => {
+                e.preventDefault(); // Prevent default jump behavior
+                
+                const navSize = getNavSize();
+                const targetId = link.getAttribute("href").substring(1);
+                const targetElement = document.getElementById(targetId);
+
+                if (targetElement) {
+                    const targetPosition =
+                        targetElement.getBoundingClientRect().top +
+                        window.scrollY -
+                        navSize;
+
+                    window.scrollTo({
+                        top: targetPosition
+                    });
+                }
+
+                history.replaceState(null, "", `#${targetId}`);
             });
         });
 


### PR DESCRIPTION
On a program page, regardless if a user:

- Navigates through the page via jump links on the side navigation bar
- Navigates through the page via jump links on the top navigation bar
- Scrolls through the different sections on the page

we want to NOT add the jump link URL to the browser history. Clicking the back button should always allow the user to return to the page they were at before the program page.